### PR TITLE
Removed the use of GenericEntity

### DIFF
--- a/demo.war/src/java/com/dw/demo/rest/resources/StudentResource.java
+++ b/demo.war/src/java/com/dw/demo/rest/resources/StudentResource.java
@@ -165,10 +165,7 @@ public class StudentResource {
 				wrappedStudents.add(wrappedStudent);
 			}
 
-			// This preserves type information for the provider
-			GenericEntity<List<HateoasStudentDto>> entity = new GenericEntity<List<HateoasStudentDto>>(wrappedStudents) {
-			};
-			return Response.ok(entity).build();
+			return Response.ok(wrappedStudents).build();
 		} finally {
 			logger.exiting(className, methodName);
 		}


### PR DESCRIPTION
Removed the use of GenericEntity in StudentResource#getAll since we use custom serialization via annotation on the DTOs.